### PR TITLE
fix: treat touchSet trailing slash as directory prefix glob

### DIFF
--- a/src/lib/merge-train.ts
+++ b/src/lib/merge-train.ts
@@ -73,7 +73,9 @@ export async function validateTouchSet(
   const violations: string[] = [];
   for (const file of changedFiles) {
     const matchesAny = touchSet.some(pattern => {
-      const glob = new Bun.Glob(pattern);
+      // Trailing slash means "this directory and everything inside it"
+      const normalized = pattern.endsWith('/') ? `${pattern}**` : pattern;
+      const glob = new Bun.Glob(normalized);
       return glob.match(file);
     });
     if (!matchesAny) {

--- a/tests/lib/merge-train.test.ts
+++ b/tests/lib/merge-train.test.ts
@@ -489,6 +489,19 @@ describe('validateTouchSet', () => {
     expect(result.changedFiles).toContain('src/lib/deep/nested.ts');
   });
 
+  it('should treat trailing slash as directory prefix glob', async () => {
+    await mustExec(['git', 'checkout', '-b', 'feature-trailing-slash', 'main'], testRepo.repoDir);
+    mkdirSync(join(testRepo.repoDir, 'ai-docs/gap-analysis'), { recursive: true });
+    writeFileSync(join(testRepo.repoDir, 'ai-docs/gap-analysis/AUDIT.md'), 'audit\n');
+    await mustExec(['git', 'add', '.'], testRepo.repoDir);
+    await mustExec(['git', 'commit', '-m', 'add audit file'], testRepo.repoDir);
+    await mustExec(['git', 'checkout', 'main'], testRepo.repoDir);
+
+    const result = await validateTouchSet('feature-trailing-slash', 'main', ['ai-docs/gap-analysis/'], { cwd: testRepo.repoDir });
+    expect(result.valid).toBe(true);
+    expect(result.changedFiles).toContain('ai-docs/gap-analysis/AUDIT.md');
+  });
+
   it('should return valid when job has no changes', async () => {
     await mustExec(['git', 'checkout', '-b', 'feature-no-changes', 'main'], testRepo.repoDir);
     await mustExec(['git', 'commit', '--allow-empty', '-m', 'empty'], testRepo.repoDir);


### PR DESCRIPTION
## Summary

- Fixes touchSet validation treating trailing `/` as a literal path instead of a directory prefix, causing false-positive violations for files inside the directory
- Adds test covering the trailing slash normalization

Closes #72

## Changes

**`src/lib/merge-train.ts`** — Normalize touchSet patterns ending with `/` to append `**` before glob matching. `ai-docs/gap-analysis/` → `ai-docs/gap-analysis/**`.

**`tests/lib/merge-train.test.ts`** — New test: `should treat trailing slash as directory prefix glob`.

## How to test

```bash
bun test
```